### PR TITLE
Add event type to v1 events

### DIFF
--- a/eventsv1/serializer.go
+++ b/eventsv1/serializer.go
@@ -21,6 +21,7 @@ import (
 type SerializableEvent struct {
 	Attributes map[string]any `json:"attributes"`
 	Trails     []string       `json:"trails"`
+	EventType  string         `json:"event_type,omitempty"`
 }
 
 // SerializeEventFromJson serializes a v1 event from datatrails eventv1 api respone


### PR DESCRIPTION
Add event type to v1 events

testing:

tested with companion changes in avid-events
all tests pass:

```
  3 skipped
  116 passed (2.0m)
```

added relevant unit tests here.

AB#10264 